### PR TITLE
Cached internal stack of LuaClosure

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,7 +1,6 @@
 <project default="all">
 	<property file="version.properties"/>
-		
-	<property name="jar.name.jme" value="luaj-jme-${version}.jar"/>
+
 	<property name="jar.name.jse" value="luaj-jse-${version}.jar"/>
 	<property name="jar.name.sources" value="luaj-sources-${version}.jar"/>
 
@@ -35,19 +34,9 @@
 	</target>
 		
 	<target name="compile" depends="wtk-libs,bcel-lib">
-		<delete dir="build/jme/src"/>
 		<delete dir="build/jse/src"/>
-		<mkdir dir="build/jme/src"/>
 		<mkdir dir="build/jse/src"/>
-		<mkdir dir="build/jme/classes"/>
 		<mkdir dir="build/jse/classes"/>
-		<copy todir="build/jme/src">
-			<fileset dir="src/core"/>
-			<fileset dir="src/jme"/>
-			<filterchain>
-				<tokenfilter><replacestring from='"Luaj 0.0"' to='"Luaj-jme ${version}"'/></tokenfilter>
-			</filterchain>
-		</copy>
 		<copy todir="build/jse/src">
 			<fileset dir="src/core"/>
 			<filterchain>
@@ -81,28 +70,21 @@
 			<pathelement path="lib/midpapi20.jar"/>
 			<pathelement path="lib/mmapi.jar"/>
 		</path>
-		<javac destdir="build/jme/classes" encoding="utf-8" source="1.3" target="1.2" bootclasspathref="wtk-libs"
-			   debug="on"
-			   srcdir="build/jme/src"/>
-		<javac destdir="build/jse/classes" encoding="utf-8" source="1.3" target="1.3"
+		<javac destdir="build/jse/classes" encoding="utf-8" source="8" target="8"
 			   classpath="lib/bcel-5.2.jar"
 			   debug="on"
 			   srcdir="build/jse/src"
 			   excludes="**/script/*,**/Lua2Java*,**/server/*,lua*"/>
-		<javac destdir="build/jse/classes" encoding="utf-8" source="1.5" target="1.5"
+		<javac destdir="build/jse/classes" encoding="utf-8" source="8" target="8"
 			   classpath="build/jse/classes"
 			   debug="on"
 			   srcdir="build/jse/src"
 			   includes="**/script/*,**/Lua2Java*,**/server/*"/>
-		<javac destdir="build/jse/classes" encoding="utf-8" source="1.3" target="1.3"
+		<javac destdir="build/jse/classes" encoding="utf-8" source="8" target="8"
 			   classpath="build/jse/classes"
 			   debug="on"
 			   srcdir="build/jse/src"
 			   includes="lua*"/>
-	</target>
-	
-	<target name="jar-jme" depends="compile">
-		<jar destfile="${jar.name.jme}" basedir="build/jme/classes"/>
 	</target>
 	
 	<target name="jar-jse" depends="compile">
@@ -116,7 +98,6 @@
 
 	<target name="jar-jse-sources" depends="compile">
 		<jar destfile="${jar.name.sources}">
-		    <fileset dir="build/jme/src"/>
 		    <fileset dir="build/jse/src"/>
 		</jar>
 	</target>
@@ -132,7 +113,6 @@
 				windowtitle="Luaj API">
 		    <fileset dir="src/core" defaultexcludes="yes" includes="org/luaj/vm2/*.java,org/luaj/vm2/compiler/LuaC.java,org/luaj/vm2/lib/*.java"/>
 		    <fileset dir="src/jse" defaultexcludes="yes" includes="org/luaj/vm2/lib/jse/*.java,org/luaj/vm2/luajc/LuaJC.java,org/luaj/vm2/server/*.java"/>
-		    <fileset dir="src/jme" defaultexcludes="yes" includes="org/luaj/vm2/lib/jme/*.java"/>
 			<doctitle><![CDATA[<h1>Luaj API</h1>]]></doctitle>
 			<bottom><![CDATA[<i>Copyright &#169; 2007-2015 Luaj.org. All Rights Reserved.</i>]]></bottom>
 			<tag name="todo" scope="all" description="To do:"/>
@@ -164,7 +144,6 @@
 				<include name="android/assets/**"/>
 				<include name="android/res/**"/>
 				<include name="android/src/**"/>
-				<include name="jme/*.java"/>
 				<include name="jse/*.java"/>
 				<include name="lua/*.*"/>
 				<include name="maven/pom.xml"/>
@@ -207,6 +186,6 @@
 		</exec>
 	</target>
 
-	<target name="all" depends="clean,jar-jme,jar-jse,jar-jse-sources"/>
+	<target name="all" depends="clean,jar-jse,jar-jse-sources"/>
 		
 </project>

--- a/build.xml
+++ b/build.xml
@@ -82,23 +82,23 @@
 			<pathelement path="lib/mmapi.jar"/>
 		</path>
 		<javac destdir="build/jme/classes" encoding="utf-8" source="1.3" target="1.2" bootclasspathref="wtk-libs"
-		    debug="on"
-			srcdir="build/jme/src"/>
-		<javac destdir="build/jse/classes" encoding="utf-8" source="1.3" target="1.3"
-			classpath="lib/bcel-5.2.jar"
-			debug="on"
-			srcdir="build/jse/src"
-			excludes="**/script/*,**/Lua2Java*,**/server/*,lua*"/>
-		<javac destdir="build/jse/classes" encoding="utf-8" source="1.5" target="1.5"
-			classpath="build/jse/classes"
-			debug="on"
-			srcdir="build/jse/src"
-			includes="**/script/*,**/Lua2Java*,**/server/*"/>
-		<javac destdir="build/jse/classes" encoding="utf-8" source="1.3" target="1.3"
-			classpath="build/jse/classes"
-			debug="on"
-			srcdir="build/jse/src"
-			includes="lua*"/>
+			   debug="on"
+			   srcdir="build/jme/src"/>
+		<javac destdir="build/jse/classes" encoding="utf-8" source="8" target="8"
+			   classpath="lib/bcel-5.2.jar"
+			   debug="on"
+			   srcdir="build/jse/src"
+			   excludes="**/script/*,**/Lua2Java*,**/server/*,lua*"/>
+		<javac destdir="build/jse/classes" encoding="utf-8" source="8" target="8"
+			   classpath="build/jse/classes"
+			   debug="on"
+			   srcdir="build/jse/src"
+			   includes="**/script/*,**/Lua2Java*,**/server/*"/>
+		<javac destdir="build/jse/classes" encoding="utf-8" source="8" target="8"
+			   classpath="build/jse/classes"
+			   debug="on"
+			   srcdir="build/jse/src"
+			   includes="lua*"/>
 	</target>
 	
 	<target name="jar-jme" depends="compile">

--- a/build.xml
+++ b/build.xml
@@ -84,17 +84,17 @@
 		<javac destdir="build/jme/classes" encoding="utf-8" source="1.3" target="1.2" bootclasspathref="wtk-libs"
 			   debug="on"
 			   srcdir="build/jme/src"/>
-		<javac destdir="build/jse/classes" encoding="utf-8" source="8" target="8"
+		<javac destdir="build/jse/classes" encoding="utf-8" source="1.3" target="1.3"
 			   classpath="lib/bcel-5.2.jar"
 			   debug="on"
 			   srcdir="build/jse/src"
 			   excludes="**/script/*,**/Lua2Java*,**/server/*,lua*"/>
-		<javac destdir="build/jse/classes" encoding="utf-8" source="8" target="8"
+		<javac destdir="build/jse/classes" encoding="utf-8" source="1.5" target="1.5"
 			   classpath="build/jse/classes"
 			   debug="on"
 			   srcdir="build/jse/src"
 			   includes="**/script/*,**/Lua2Java*,**/server/*"/>
-		<javac destdir="build/jse/classes" encoding="utf-8" source="8" target="8"
+		<javac destdir="build/jse/classes" encoding="utf-8" source="1.3" target="1.3"
 			   classpath="build/jse/classes"
 			   debug="on"
 			   srcdir="build/jse/src"

--- a/src/core/org/luaj/vm2/LuaClosure.java
+++ b/src/core/org/luaj/vm2/LuaClosure.java
@@ -91,6 +91,8 @@ public class LuaClosure extends LuaFunction {
 	public UpValue[] upValues;
 	
 	final Globals globals;
+
+	private LuaValue[] stackCache = null;
 	
 	/** Create a closure around a Prototype with a specific environment.
 	 * If the prototype has upvalues, the environment will be written into the first upvalue.
@@ -131,9 +133,11 @@ public class LuaClosure extends LuaFunction {
 	
 	private LuaValue[] getNewStack() {
 		int max = p.maxstacksize;
-		LuaValue[] stack = new LuaValue[max];
-		System.arraycopy(NILS, 0, stack, 0, max);
-		return stack;
+		if (stackCache == null || stackCache.length != max) {
+			stackCache = new LuaValue[max];
+		}
+		System.arraycopy(NILS, 0, stackCache, 0, max);
+		return stackCache;
 	}
 	
 	public final LuaValue call() {

--- a/src/core/org/luaj/vm2/LuaClosure.java
+++ b/src/core/org/luaj/vm2/LuaClosure.java
@@ -23,6 +23,8 @@ package org.luaj.vm2;
 
 import org.luaj.vm2.lib.DebugLib.CallFrame;
 
+import java.util.Stack;
+
 /**
  * Extension of {@link LuaFunction} which executes lua bytecode.
  * <p>
@@ -85,6 +87,8 @@ import org.luaj.vm2.lib.DebugLib.CallFrame;
  */
 public class LuaClosure extends LuaFunction {
 	private static final UpValue[] NOUPVALUES = new UpValue[0];
+
+	private static final int MAX_STACK_CACHE_SIZE = 20;
 	
 	public final Prototype p;
 
@@ -92,7 +96,7 @@ public class LuaClosure extends LuaFunction {
 	
 	final Globals globals;
 
-	private LuaValue[] stackCache = null;
+	private final Stack<LuaValue[]> freeStacks = new Stack<>();
 	
 	/** Create a closure around a Prototype with a specific environment.
 	 * If the prototype has upvalues, the environment will be written into the first upvalue.
@@ -133,43 +137,94 @@ public class LuaClosure extends LuaFunction {
 	
 	private LuaValue[] getNewStack() {
 		int max = p.maxstacksize;
-		if (stackCache == null || stackCache.length != max) {
-			stackCache = new LuaValue[max];
+		LuaValue[] stack;
+		if (freeStacks.empty()) {
+			stack = new LuaValue[max];
+		} else {
+			stack = freeStacks.pop();
+			if (stack.length != max) {
+				stack = new LuaValue[max];
+			}
 		}
-		System.arraycopy(NILS, 0, stackCache, 0, max);
-		return stackCache;
+		System.arraycopy(NILS, 0, stack, 0, max);
+		return stack;
+	}
+
+	private void releaseStack(LuaValue[] stack) {
+		if (freeStacks.size() < MAX_STACK_CACHE_SIZE) {
+			freeStacks.push(stack);
+		}
 	}
 	
 	public final LuaValue call() {
 		LuaValue[] stack = getNewStack();
-		return execute(stack,NONE).arg1();
+		LuaValue result = execute(stack, NONE).arg1();
+		releaseStack(stack);
+		return result;
 	}
 
 	public final LuaValue call(LuaValue arg) {
 		LuaValue[] stack = getNewStack();
+		LuaValue result;
 		switch ( p.numparams ) {
-		default: stack[0]=arg; return execute(stack,NONE).arg1();
-		case 0: return execute(stack,arg).arg1();
+			default:
+				stack[0]=arg;
+				result = execute(stack,NONE).arg1();
+				break;
+			case 0:
+				result = execute(stack,arg).arg1();
+				break;
 		}
+		releaseStack(stack);
+		return result;
 	}
 	
 	public final LuaValue call(LuaValue arg1, LuaValue arg2) {
 		LuaValue[] stack = getNewStack();
+		LuaValue result;
 		switch ( p.numparams ) {
-		default: stack[0]=arg1; stack[1]=arg2; return execute(stack,NONE).arg1();
-		case 1: stack[0]=arg1; return execute(stack,arg2).arg1();
-		case 0: return execute(stack,p.is_vararg!=0? varargsOf(arg1,arg2): NONE).arg1();
+			default:
+				stack[0]=arg1;
+				stack[1]=arg2;
+				result = execute(stack,NONE).arg1();
+				break;
+			case 1:
+				stack[0]=arg1;
+				result = execute(stack,arg2).arg1();
+				break;
+			case 0:
+				result = execute(stack,p.is_vararg!=0? varargsOf(arg1,arg2): NONE).arg1();
+				break;
 		}
+		releaseStack(stack);
+		return result;
 	}
 
 	public final LuaValue call(LuaValue arg1, LuaValue arg2, LuaValue arg3) {
 		LuaValue[] stack = getNewStack();
+		LuaValue result;
 		switch ( p.numparams ) {
-		default: stack[0]=arg1; stack[1]=arg2; stack[2]=arg3; return execute(stack,NONE).arg1();
-		case 2: stack[0]=arg1; stack[1]=arg2; return execute(stack,arg3).arg1();
-		case 1: stack[0]=arg1; return execute(stack,p.is_vararg!=0? varargsOf(arg2,arg3): NONE).arg1();
-		case 0: return execute(stack,p.is_vararg!=0? varargsOf(arg1,arg2,arg3): NONE).arg1();
+			default:
+				stack[0]=arg1;
+				stack[1]=arg2;
+				stack[2]=arg3;
+				result = execute(stack,NONE).arg1();
+				break;
+			case 2:
+				stack[0]=arg1;
+				stack[1]=arg2;
+				result = execute(stack,arg3).arg1();
+				break;
+			case 1:
+				stack[0]=arg1;
+				result = execute(stack,p.is_vararg!=0? varargsOf(arg2,arg3): NONE).arg1();
+				break;
+			case 0:
+				result = execute(stack,p.is_vararg!=0? varargsOf(arg1,arg2,arg3): NONE).arg1();
+				break;
 		}
+		releaseStack(stack);
+		return result;
 	}
 
 	public final Varargs invoke(Varargs varargs) {
@@ -180,7 +235,9 @@ public class LuaClosure extends LuaFunction {
 		LuaValue[] stack = getNewStack();
 		for ( int i=0; i<p.numparams; i++ )
 			stack[i] = varargs.arg(i+1);
-		return execute(stack,p.is_vararg!=0? varargs.subargs(p.numparams+1): NONE);
+		Varargs result = execute(stack,p.is_vararg!=0? varargs.subargs(p.numparams+1): NONE);
+		releaseStack(stack);
+		return result;
 	}
 	
 	protected Varargs execute( LuaValue[] stack, Varargs varargs ) {


### PR DESCRIPTION
`LuaClosure` が頻繁に実行されると `getNewStack` が頻繁に呼び出され大量の `stack` が生成されメモリを圧迫するのでキャッシュ化。各インスタンスごとに20件まで (see `MAX_STACK_CACHE_SIZE`) を `Stack<LuaValue[]>` で管理する。

## `Stack<>` で管理している理由

実行終了前 (`stack` 解放前) に再帰呼び出しなどによって同じインスタンスが実行される場合、新たな `stack` が必要になり、単一のキャッシュを使い回すことができない。そのため、実行が完了した際にキャッシュに回し、それをCollectionで複数管理する方針を採用した。

また、 `stack` のサイズが異なる場合は再生成が必要になるため、 LIFO Stack を使用することで、同じ階層での呼び出しで同じサイズの `stack` を再利用させることによる再生成の抑制を狙った。

## 注意点

- 頻繁に実行しなければ不要
- スレッドセーフではない
- キャッシュ化したスタックはLuaClosureインスタンス自体がGCされないとメモリに残り続ける
- Java SE 8以上をサポートし、Java MEでは動作しない

[luaj-jse-3.0.2-custom.jar.zip](https://github.com/Getaji/luaj/files/12025512/luaj-jse-3.0.2-custom.jar.zip)

